### PR TITLE
Fixing a spurious \r on the localization autoLOC_SMIndustries_1000634A .

### DIFF
--- a/SM_Industries/SM_Industries.cfg
+++ b/SM_Industries/SM_Industries.cfg
@@ -668,8 +668,7 @@ en-us
 #autoLOC_SMIndustries_1000633 = CK VLS space Cover
 #autoLOC_SMIndustries_1000633A = CK hull2  VLS space Cover
 #autoLOC_SMIndustries_1000634 = Sonar deployable
-#autoLOC_SMIndustries_1000634A = Kerbins naval engineers had recently started mounting radars on sticks, and soon came to the conclusion that they needed a radar for underwater, early attempts resulted in nothing more than grilled fish (which is why fish are so rare)  and ships with a strange blue glow ,  and a different approach was developed Sonar, Sonar only works below water and does not harm the fish 
-This unit should be fitted inside the hull and arranged so that when deployed it is extended below the ships waterline. This unit will not lock airborne targets
+#autoLOC_SMIndustries_1000634A = Kerbins naval engineers had recently started mounting radars on sticks, and soon came to the conclusion that they needed a radar for underwater, early attempts resulted in nothing more than grilled fish (which is why fish are so rare)  and ships with a strange blue glow ,  and a different approach was developed Sonar, Sonar only works below water and does not harm the fish.  This unit should be fitted inside the hull and arranged so that when deployed it is extended below the ships waterline. This unit will not lock airborne targets
 #autoLOC_SMIndustries_1000635 = RIB 10 mtr
 #autoLOC_SMIndustries_1000635A = RIB 10 mtr small patrol craft. Suggested propulsion either Water Jet Small or outboard, no cmd fitted, requires fitting of pod or cmd seats 
 //////////////////


### PR DESCRIPTION
This pull request fixes a spurious "\r" on a localization tag, what renders part of the intended text unaccessible. 

The text for `autoLOC_SMIndustries_1000634A` intended to be:

> Kerbins naval engineers had recently started mounting radars on sticks, and soon came to the conclusion that they 
needed a radar for underwater, early attempts resulted in nothing more than grilled fish (which is why fish are so rare)  and ships with a strange blue glow ,  and a different approach was developed Sonar, Sonar only works below water and does not harm the fish. This unit should be fitted inside the hull and arranged so that when deployed it is extended below the ships waterline. This unit will not lock airborne targets

But it's instead being displayed as:

> Kerbins naval engineers had recently started mounting radars on sticks, and soon came to the conclusion that they needed a radar for underwater, early attempts resulted in nothing more than grilled fish (which is why fish are so rare)  and ships with a strange blue glow ,  and a different approach was developed Sonar, Sonar only works below water and does not harm the fish

This pull request restores the intended behaviour.